### PR TITLE
Changed from innerHTML to outerHTML

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "get-started"
+    ]
+}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -23,7 +23,7 @@ test('test that App component renders', () => {
 test('test that new-item-button is a button', () => {
   render(<App/>, container);
   const element = screen.getByTestId('new-item-button');
-  expect(element).toHaveTextContent('Add');
+  expect(element.outerHTML.toLowerCase().includes("button")).toBe(true)
 });
 
 test('test that new-item-input is an input ', () => {

--- a/src/component/AddTodo.js
+++ b/src/component/AddTodo.js
@@ -44,6 +44,6 @@ class AddTodo extends Component {
         </div>
       );
     }
-  }
+  } 
   
   export default AddTodo;


### PR DESCRIPTION
Tests were failing when using `innerHTML`.
Reason being is because the button element has a span inside of it which is what was being returned.
![w1inquiryInnerHTML](https://github.com/2023-IBM-Accelerate-SW-Track/to-do-list_week1-tajahouse/assets/59518501/7bde4d91-10ba-4db5-9f2a-a24b64cb3149)

`outerHTML` will return the entire button element.
